### PR TITLE
Some commits improving usability for benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,60 +1,58 @@
-cmake_minimum_required(VERSION 2.8)
-find_package(CUDA REQUIRED)
+cmake_minimum_required(VERSION 3.0)
+project(parsi VERSION 1.0.0 LANGUAGES CXX)
 
-set(
-    CUDA_NVCC_FLAGS
-    "-O3 -gencode arch=compute_35,code=sm_35 --std=c++11"
-    #"-g -O3 -lineinfo -gencode arch=compute_35,code=sm_35 --std=c++11"
-    )
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set( 
-    CMAKE_CXX_FLAGS
-    #"-Og -g --std=c++11"
-    "-O3 -march=native --std=c++11"
-    )
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
+ENDIF(NOT CMAKE_BUILD_TYPE)
 
-list (APPEND CUDA_NVCC_FLAGS --compiler-bindir /usr/bin/gcc-4.8)
-
-
-
-cuda_add_executable(
-    parity
+add_executable(parsi
     main.cpp 
-
     game.cpp 
     game.h
-
-    gpu_game.cpp
-    gpu_game.h
-
     cpu_parity.cpp 
     cpu_parity.h
-
     cpu_bv.cpp 
     cpu_bv.h
-
     cpu_list_ranking.cpp
     cpu_list_ranking.h
-
     cpu_vj.cpp
     cpu_vj.h
-
-    gpu_util.cpp
-    gpu_util.h
-
-    gpu_parity.cu
-    gpu_parity.h
-
-    gpu_list_ranking.cu
-    gpu_list_ranking.h
-
     cpu_bf.cpp
     cpu_bf.h
-
     valuation.h
     valuation.cpp
-
     si.h
-    )
+)
+set(CMAKE_CXX_FLAGS "-O3 -march=native")
+target_link_libraries(parsi pthread boost_iostreams)
 
-target_link_libraries(parity pthread boost_iostreams)
+option(WITH_CUDA "Also build psi_gpu requiring CUDA" OFF)
+
+if(WITH_CUDA)
+    set(CUDA_HOST_COMPILER /usr/bin/gcc-4.9)
+    find_package(CUDA REQUIRED)
+    set(CUDA_NVCC_FLAGS "-O3 -gencode arch=compute_35,code=sm_35 --std=c++11 -Xcompiler -fPIC")
+
+    cuda_add_executable(
+        gpuparsi
+        gpumain.cpp 
+        game.cpp 
+        game.h
+        gpu_game.cpp
+        gpu_game.h
+        gpu_util.cpp
+        gpu_util.h
+        gpu_parity.cu
+        gpu_parity.h
+        gpu_list_ranking.cu
+        gpu_list_ranking.h
+        valuation.h
+        valuation.cpp
+        si.h
+    )
+    set_property(TARGET gpuparsi PROPERTY POSITION_INDEPENDENT_CODE ON)
+    target_link_libraries(gpuparsi pthread boost_iostreams)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,4 +57,4 @@ cuda_add_executable(
     si.h
     )
 
-target_link_libraries(parity pthread)
+target_link_libraries(parity pthread boost_iostreams)

--- a/cpu_list_ranking.cpp
+++ b/cpu_list_ranking.cpp
@@ -1,5 +1,4 @@
 #include "cpu_list_ranking.h"
-#include "gpu_list_ranking.h"
 #include "valuation.h"
 #include <thread>
 #include <vector>

--- a/game.h
+++ b/game.h
@@ -30,6 +30,7 @@ public:
 
 
     void parse_pgsolver(std::string filename);
+    void parse_pgsolver(std::istream &in);
 };
 
 #endif

--- a/gpumain.cpp
+++ b/gpumain.cpp
@@ -1,9 +1,7 @@
 #include "game.h"
-#include "cpu_parity.h"
-#include "cpu_bf.h"
-#include "cpu_list_ranking.h"
-#include "cpu_vj.h"
-#include "cpu_bv.h"
+#include "gpu_game.h"
+#include "gpu_parity.h"
+#include "gpu_list_ranking.h"
 #include "valuation.h"
 #include <fstream>
 #include <iostream>
@@ -54,28 +52,6 @@ void solve_si(StrategyImprovement& si, int* br_count, int* iter_count, bool rese
 
 }
 
-template <typename T> void solve_bf(CPU_BellmanFord<T>& si, int* br_count, int* iter_count, bool reset)
-{
-    si.init_strat();
-
-    while(true)
-    {
-
-        si.best_response(br_count);
-
-        si.mark_solved(0);
-
-        (*iter_count)++;
-
-        int total_switched = si.switch_strategy(0);
-        //cout << "Total switched: " << total_switched << endl;
-        if(total_switched == 0)
-            break;
-    }
-
-    //cout << "Solved after " << iter_count << " iterations" << endl; 
-}
-
 // Run a timed test of a strategy improvement algorithm
 template <typename T> double test(T& si, void (*f)(T&, int*, int*, bool), bool reset)
 {
@@ -91,7 +67,7 @@ template <typename T> double test(T& si, void (*f)(T&, int*, int*, bool), bool r
 
     double solve_time = (end.tv_sec - start.tv_sec) + (end.tv_usec - start.tv_usec)/1000000.0;
 
-    cout << std::fixed << solve_time << " " << iter_count << " " << br_count << endl;
+    cout << solve_time << " " << iter_count << " " << br_count << endl;
 }
 
 // Checks that alg1 and alg2 give the same answer
@@ -128,7 +104,7 @@ int main(int argc, char** argv)
     if(argc != 3)
     {
         cout << "usage: " << argv[0] << " [algorithm] [game]" << endl << endl;
-        cout << "    algorithms: cpu, cpubf, cpu-reset, cpubv, cpubv" << endl << endl;
+        cout << "    algorithms: gpu, gpulist" << endl << endl;
         return 1;
     }
 
@@ -150,54 +126,18 @@ int main(int argc, char** argv)
         return -1;
     }
 
-    if(algorithm == "cpu")
+    if(algorithm == "gpu")
     {
-        CPUParity cpu = CPUParity(g);
-        test<StrategyImprovement>(cpu, &solve_si, false);
+        GPUGame gpu_g(g);
+        GPUParity gpu(g, gpu_g);
+        test<StrategyImprovement>(gpu, &solve_si, false);
     }
-    else if(algorithm == "cpu-reset")
+    else if(algorithm == "gpulist")
     {
-        CPUParity cpu = CPUParity(g);
-        test<StrategyImprovement>(cpu, &solve_si, true);
+        GPUGame gpu_g(g);
+        GPUList gpu_list(g, gpu_g);
+        test<StrategyImprovement>(gpu_list, &solve_si, false);
     }
-    else if(algorithm == "cpubv")
-    {
-        CPUBV<ArrayVal> cpu = CPUBV<ArrayVal>(g);
-        test<StrategyImprovement>(cpu, &solve_si, false);
-    }
-    //else if(algorithm == "cpubvmap")
-    //{
-        //CPUBV<MapVal> cpu = CPUBV<MapVal>(g);
-        //test<StrategyImprovement>(cpu, &solve_si);
-        ////CPUBV<ArrayVal> cpu2 = CPUBV<ArrayVal>(g);
-        ////test<StrategyImprovement>(cpu2, &solve_si);
-        ////cout << verify(cpu, cpu2) << endl;
-    //}
-    else if(algorithm == "cpubf")
-    {
-        CPU_BellmanFord<ArrayVal> cpu_bf = CPU_BellmanFord<ArrayVal>(g);
-        test(cpu_bf, &solve_bf, false);
-
-    }
-    else if(algorithm == "cpulist")
-    {
-        CPUList<ArrayVal> cpu_list = CPUList<ArrayVal>(g, 8);
-        test<StrategyImprovement>(cpu_list, &solve_si, false);
-
-
-    }
-    //else if(algorithm == "cpuvj")
-    //{
-        //Game g2 = g;
-        //g2.unique_priority_transform();
-        //CPUVJ<MapVal> cpu_vj = CPUVJ<MapVal>(g2);
-        //test<StrategyImprovement>(cpu_vj, &solve_si);
-
-        ////GPUGame gpu_g(g);
-        ////GPUList gpu_list(g, gpu_g);
-        ////test<StrategyImprovement>(gpu_list, &solve_si);
-        ////cout << verify(cpu_vj, gpu_list) << endl;
-    //}
     else
     {
         cout << "unknown algorithm: " << algorithm << endl;

--- a/main.cpp
+++ b/main.cpp
@@ -125,10 +125,10 @@ bool verify(StrategyImprovement& alg1, StrategyImprovement& alg2)
 
 int main(int argc, char** argv)
 {
-    if(argc != 3)
+    if(argc < 3)
     {
-        cout << "usage: " << argv[0] << " [algorithm] [game]" << endl << endl;
-        cout << "    algorithms: cpu, cpubf, cpu-reset, cpubv, cpubv" << endl << endl;
+        cout << "usage: " << argv[0] << " [algorithm] [game] [threads-for-cpulist]" << endl << endl;
+        cout << "    algorithms: cpu, cpubf, cpu-reset, cpubv, cpulist" << endl << endl;
         return 1;
     }
 
@@ -181,8 +181,14 @@ int main(int argc, char** argv)
     }
     else if(algorithm == "cpulist")
     {
-        CPUList<ArrayVal> cpu_list = CPUList<ArrayVal>(g, 8);
-        test<StrategyImprovement>(cpu_list, &solve_si, false);
+        int w = 8; // default: 8 threads
+        if (argc > 3) w = atoi(argv[3]);
+        if (w <= 0) {
+            cout << "invalid number of threads." << endl;
+        } else {
+            CPUList<ArrayVal> cpu_list = CPUList<ArrayVal>(g, w);
+            test<StrategyImprovement>(cpu_list, &solve_si, false);
+        }
 
 
     }

--- a/main.cpp
+++ b/main.cpp
@@ -94,7 +94,7 @@ template <typename T> double test(T& si, void (*f)(T&, int*, int*, bool), bool r
 
     double solve_time = (end.tv_sec - start.tv_sec) + (end.tv_usec - start.tv_usec)/1000000.0;
 
-    cout << solve_time << " " << iter_count << " " << br_count << endl;
+    cout << std::fixed << solve_time << " " << iter_count << " " << br_count << endl;
 }
 
 // Checks that alg1 and alg2 give the same answer


### PR DESCRIPTION
For the experiments with Oink and other tools I changed some things.

The game parser was unable to parse games with many edges. I rewrote the parser.

The tool now supports compressed games (bzip2 and gzip) but requires the Boost library to be installed for this.

The solving time is now written in a fixed format instead of scientific format. This is helpful for parsing the results of experiments.

The GPU and CPU solvers are now separated so the CPU solver can be compiled without CUDA.

A third parameter <threads> for the cpulist solver controls the number of threads.